### PR TITLE
Migrate to std::shared_ptr

### DIFF
--- a/src/KronPhotometry.cc
+++ b/src/KronPhotometry.cc
@@ -247,7 +247,7 @@ struct KronAperture {
     PTR(KronAperture) transform(afw::geom::AffineTransform const& trans) const {
         afw::geom::Point2D const center = trans(getCenter());
         afw::geom::ellipses::Axes const axes(*getAxes().transform(trans.getLinear()).copy());
-        return boost::make_shared<KronAperture>(center, axes);
+        return std::make_shared<KronAperture>(center, axes);
     }
 
 private:
@@ -343,7 +343,7 @@ PTR(KronAperture) KronAperture::determine(ImageT const& image, // Image to measu
         axes.scale(radius/axes.getDeterminantRadius()); // set axes to our current estimate of R_K
     }
 
-    return boost::make_shared<KronAperture>(center, axes);
+    return std::make_shared<KronAperture>(center, axes);
 }
 
 // Photometer an image with a particular aperture


### PR DESCRIPTION
Makes the following replacements:

- boost::shared_ptr -> std::shared_ptr
- boost::weak_ptr -> std::weak_ptr
- boost::static_pointer_cast -> std::static_pointer_cast
- boost::dynamic_pointer_cast -> std::dynamic_pointer_cast
- boost::const_pointer_cast -> std::const_pointer_cast
- boost::reinterpret_pointer_cast -> std::reinterpret_pointer_cast
- boost::enamble_shared_from_this -> std::enable_shared_from_this
- boost pointer related includes -> standard library memory