### PR TITLE
make source of Kron radius configurable for forced mode

### DIFF
--- a/include/lsst/meas/extensions/photometryKron.h
+++ b/include/lsst/meas/extensions/photometryKron.h
@@ -62,6 +62,8 @@ public:
                        "Use the Footprint size as part of initial estimate of Kron radius");
     LSST_CONTROL_FIELD(smoothingSigma, double,
                        "Smooth image with N(0, smoothingSigma^2) Gaussian while estimating R_K");
+    LSST_CONTROL_FIELD(refRadiusName, std::string,
+                       "Name of field specifying reference Kron radius for forced measurement");
 
     KronFluxControl() :
         fixed(false),
@@ -72,7 +74,8 @@ public:
         minimumRadius(0.0),
         enforceMinimumRadius(true),
         useFootprintRadius(false),
-        smoothingSigma(-1.0)
+        smoothingSigma(-1.0),
+        refRadiusName("ext_photometryKron_KronFlux_radius")
     {}
 };
 

--- a/src/KronPhotometry.cc
+++ b/src/KronPhotometry.cc
@@ -433,7 +433,7 @@ void KronFluxAlgorithm::_applyForced(
         afw::geom::AffineTransform const & refToMeas
     ) const
 {
-    float const radius = reference.get(reference.getSchema().find<float>(_name + "_radius").key);
+    float const radius = reference.get(reference.getSchema().find<float>(_ctrl.refRadiusName).key);
     KronAperture const aperture(reference, refToMeas, radius);
     _applyAperture(source, exposure, aperture);
     if (exposure.getPsf()) {


### PR DESCRIPTION
The source of the Kron radius was hard-wired to _name+"_radius",
but this doesn't work for the undeblended version (which has a
different name that doesn't exist in the reference catalog).
Making the source configurable solves this problem.