### PR TITLE
DM-12659: Clean up Doxygen tagfile imports

### DIFF
--- a/ups/meas_extensions_photometryKron.cfg
+++ b/ups/meas_extensions_photometryKron.cfg
@@ -3,7 +3,7 @@
 import lsst.sconsUtils
 
 dependencies = {
-    "required": ["utils", "afw", "meas_base"],
+    "required": ["cpputils", "afw", "meas_base"],
     "buildRequired": ["pybind11"],
 }
 


### PR DESCRIPTION
This PR stops C++ imports of `utils`, fixing a missing tagfile error; `utils` is pure Python, and it's `cpputils` that could potentially produce Doxygen tagfiles.