### PR TITLE
DM-52492: Fixes for clang++ 19

### DIFF
--- a/src/KronPhotometry.cc
+++ b/src/KronPhotometry.cc
@@ -128,7 +128,8 @@ public:
 #if 0
                            _sumVar(0.0), _sumRVar(0.0),
 #endif
-                           _imageX0(mimage.getX0()), _imageY0(mimage.getY0())
+                           _imageX0(mimage.getX0()), _imageY0(mimage.getY0()),
+                           _imageWidth(mimage.getWidth()), _imageHeight(mimage.getHeight())
         {}
 
     /// @brief Reset everything for a new Footprint
@@ -139,17 +140,16 @@ public:
         _sumVar = _sumRVar = 0.0;
 #endif
 
-        MaskedImageT const& mimage = this->getImage();
         geom::Box2I const& bbox(foot.getBBox());
         int const x0 = bbox.getMinX(), y0 = bbox.getMinY(), x1 = bbox.getMaxX(), y1 = bbox.getMaxY();
 
         if (x0 < _imageX0 || y0 < _imageY0 ||
-            x1 >= _imageX0 + mimage.getWidth() || y1 >= _imageY0 + mimage.getHeight()) {
+            x1 >= _imageX0 + _imageWidth || y1 >= _imageY0 + _imageHeight) {
             throw LSST_EXCEPT(lsst::pex::exceptions::OutOfRangeError,
                               (boost::format("Footprint %d,%d--%d,%d doesn't fit in image %d,%d--%d,%d")
                                % x0 % y0 % x1 % y1
                                % _imageX0 % _imageY0
-                               % (_imageX0 + mimage.getWidth() - 1) % (_imageY0 + mimage.getHeight() - 1)
+                               % (_imageX0 + _imageWidth - 1) % (_imageY0 + _imageHeight - 1)
                               ).str());
         }
     }
@@ -215,6 +215,7 @@ private:
     double _sumRVar;                    // sum of R*R*Var(I)
 #endif
     int const _imageX0, _imageY0;       // origin of image we're measuring
+    int const _imageWidth, _imageHeight; // size of image we're measuring
 
 };
 } // end anonymous namespace

--- a/ups/meas_extensions_photometryKron.cfg
+++ b/ups/meas_extensions_photometryKron.cfg
@@ -3,7 +3,7 @@
 import lsst.sconsUtils
 
 dependencies = {
-    "required": ["cpputils", "afw", "meas_base"],
+    "required": ["afw", "meas_base"],
     "buildRequired": ["pybind11"],
 }
 

--- a/ups/meas_extensions_photometryKron.table
+++ b/ups/meas_extensions_photometryKron.table
@@ -1,4 +1,9 @@
+setupRequired(afw)
+setupRequired(daf_base)
 setupRequired(meas_base)
+
+# For tests
+setupRequired(utils)
 setupOptional(meas_algorithms) # used by a unit test
 
 envPrepend(LD_LIBRARY_PATH, ${PRODUCT_DIR}/lib)


### PR DESCRIPTION
This fixes the following error from clang++ 19:

```cpp
src/KronPhotometry.cc:142:44: error: no member named 'getImage' in 'FootprintFindMoment<MaskedImageT, WeightImageT>'
  142 |         MaskedImageT const& mimage = this->getImage();
      |                                      ~~~~  ^
1 error generated.
```